### PR TITLE
feat: made changes to add 'Cross' symbol to toggle the navbar OFF in mobile view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-helmet-async": "^1.3.0",
-        "react-icons": "^4.7.1",
+        "react-icons": "^4.8.0",
         "react-js-loader": "^0.1.0",
         "react-router-dom": "^6.4.3",
         "react-scripts": "^2.1.3",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-helmet-async": "^1.3.0",
-    "react-icons": "^4.7.1",
+    "react-icons": "^4.8.0",
     "react-js-loader": "^0.1.0",
     "react-router-dom": "^6.4.3",
     "react-scripts": "^2.1.3",

--- a/src/components/Navbar.jsx
+++ b/src/components/Navbar.jsx
@@ -1,4 +1,4 @@
-import React, { useContext, useEffect } from "react";
+import React, { useContext } from "react";
 import "../styles/Navbar.css";
 import solidarity from "../assets/pictures/solidarity.png";
 import { Link, useNavigate, useLocation } from "react-router-dom";
@@ -6,11 +6,14 @@ import ProfilePicture from "../assets/pictures/ProfilePicture.png";
 import Cookies from "js-cookie";
 import MilanContext from "../context/MilanContext";
 import Modal from "./Modal";
+import { FaBars } from "react-icons/fa";
+import { IoMdClose } from "react-icons/io";
 
 const Navbar = () => {
   const navigate = useNavigate();
   const location = useLocation();
   const { isSignUpModalOpen, toggleSignUpModal } = useContext(MilanContext);
+  const { isNavbarOpen, toggleNavbar } = useContext(MilanContext);
 
   const handleNavigate = () => {
     if (Cookies.get("token")) {
@@ -27,17 +30,6 @@ const Navbar = () => {
     navigate(url);
   };
 
-  useEffect(() => {
-    if (isSignUpModalOpen) {
-      const closeEvent = (e) => {
-        if (e.key === "Escape") {
-          toggleSignUpModal();
-        }
-      };
-      window.addEventListener("keydown", closeEvent);
-      return () => window.removeEventListener("keydown", closeEvent);
-    }
-  }, [isSignUpModalOpen]);
 
   return (
     <>
@@ -62,11 +54,17 @@ const Navbar = () => {
             aria-controls="navbarSupportedContent"
             aria-expanded="false"
             aria-label="Toggle navigation"
+            onClick={()=>toggleNavbar()}
           >
-            <span className="navbar-toggler-icon"></span>
+            {isNavbarOpen ? <IoMdClose /> : <FaBars />}
           </button>
 
-          <div className="collapse navbar-collapse" id="navbarSupportedContent">
+          <div
+            className={`collapse navbar-collapse ${
+              isNavbarOpen ? "show" : ""
+            }`}
+            id="navbarSupportedContent"
+          >
             <ul className="navbar-nav ms-auto mb-2 mb-lg-0">
               <li className="nav-item home">
                 <Link to={"/"}>Home</Link>

--- a/src/context/MilanState.jsx
+++ b/src/context/MilanState.jsx
@@ -11,6 +11,7 @@ const MilanState = (props) => {
     right: false,
   });
   const [isSignUpModalOpen, setIsSignUpModalOpen] = react.useState(false);
+  const [isNavbarOpen, setIsNavbarOpen] = react.useState(false);
 
   const toggleSignUpModal = () => {
     if (isSignUpModalOpen) {
@@ -20,6 +21,16 @@ const MilanState = (props) => {
     }
     setIsSignUpModalOpen(true);
     document.body.style.overflow = "hidden";
+  };
+
+  const toggleNavbar = () => {
+    if(isNavbarOpen){
+      setIsNavbarOpen(false);
+      return;
+    }
+    else{
+      setIsNavbarOpen(true);
+    }
   };
 
   return (
@@ -33,6 +44,8 @@ const MilanState = (props) => {
         setState,
         isSignUpModalOpen,
         toggleSignUpModal,
+        isNavbarOpen,
+        toggleNavbar
       }}
     >
       {props.children}


### PR DESCRIPTION
…

## Related Issue 

Closes: #596 

#### Describe the changes you've made ✍
I have made the changes in the navbar toggler for the mobile view. I have added the react icons for the same and used the UseState hook to control the state of the navbar button.
Initially the navbar toggler button was not showing the close icon once opened, But now with the following code improvement the navbar shows a 'CLOSE' icon when the navbar is toggled 'ON'


#### Screenshots (if any) 📸

