### PR TITLE
fix: correct import path for CreateEvent component

### DIFF
--- a/src/pages/events/all/Events.jsx
+++ b/src/pages/events/all/Events.jsx
@@ -1,7 +1,7 @@
 import { Button, Footer, Loading, Navbar } from "@components/shared";
 import EventCard from "@components/shared/cards/event/EventCard";
 import EventSlider from "@components/shared/cards/event/EventSlider";
-import CreateEvent from "@components/shared/createEvent/createEvent";
+import CreateEvent from "@components/shared/createEvent/CreateEvent";
 import ComponentHelmet from "@utils/ComponentHelmet";
 import { useState } from "react";
 import { CiFilter } from "react-icons/ci";


### PR DESCRIPTION
<!--- THESE ARE COMMENTS, AND WON'T BE VISIBLE, DON'T WORRY 

🔴🔴🔴 PLEASE USE PROPER PR TITLE, IT'S SUPER IMPORTANT 
🔴🔴🔴 ALL LOWER CASE CHARACTERS ONLY 

EXAMPLES👇🏻👇🏻  

feat: added new footer links
fix: changes to the buggy buttons
docs: upgrades to the readme file
chore(deps): bumping up the dependencies
chore(refactor): refactored legacy codes for server

🔴🔴🔴 MAKE SURE YOU FOLLOW THESE !  -->


<!--- ADD YOUR ISSUE NUMBER LIKE #11 (NO SPACES BETWEEN # & ISSUE NUMBER) -->

closes #


### 👷🏻 Changes made  

Fixed a critical import case sensitivity bug that prevented the app from running in development mode. The `CreateEvent` component was being imported with incorrect casing (`createEvent` instead of `CreateEvent`) in [src/pages/events/all/Events.jsx](src/pages/events/all/Events.jsx). 

On Linux systems with case-sensitive file systems, this caused the module bundler to fail during `npm run dev`. Updated the import path to match the actual filename with proper casing to resolve the module resolution error.


### 📸 Screenshots 
<img width="1599" height="721" alt="DeepinScreenshot_select-area_20260116002904" src="https://github.com/user-attachments/assets/02dc57e7-da16-40bc-a579-bbc18377cff5" />
<img width="1546" height="402" alt="DeepinScreenshot_select-area_20260116002826" src="https://github.com/user-attachments/assets/573cafad-1111-410e-8b5f-2cb06a753529" />
