### PR TITLE
docs: add per-feature architecture specs, CLAUDE.md, and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+## agentic workflow
+
+- Read [docs/specs/README.md](./docs/specs/README.md) first — it's the master map of this codebase: architecture, state management, the API layer, and one file per feature.
+- Read [docs/specs/known-issues.md](./docs/specs/known-issues.md) before touching any area it flags — duplicated implementations, dead code, unrouted pages, and validation that doesn't actually block submission are all cataloged there so you don't rediscover them the hard way or accidentally build on top of the broken half of a duplicate pair.
+- There is no `PRODUCT_SPEC.md`, task-spec template, or Definition-of-Done doc in this repo yet — `docs/specs/` is the closest thing to a source of truth today. If this repo grows one later, this file should point to it.
+- There is no graphify knowledge graph set up for this repo yet. Say if you want one.
+- This repo has no automated unit-test runner (no `test` script) — `cypress:run`/`cypress:open` (Cypress e2e, one minimal spec today) is the only test tooling. Don't claim something is "tested" without running it through that or manually verifying.
+
+## git / branching
+
+- Never create a new branch on your own initiative. Always work on the branch Tamal has already checked out or explicitly named for the task.
+- If you're on `main` and about to commit, stop and ask which branch to use instead of branching automatically.
+- Creating a branch requires explicit consent for that specific instance — being told to branch once earlier in a session doesn't authorize doing it again later unasked.
+
+## backend boundary
+
+This repo is frontend-only (`milan-frontend`). The backend is a separate repo, [NGOWorld-Backend](https://github.com/ngoworldcommunity/NGOWorld-Backend), not checked out locally.
+Don't guess at request/response shapes beyond what `src/integrations/ApiEndpoints.js` and the existing call sites already show — if a change needs a new/changed backend contract, say so explicitly rather than inventing fields.
+
+## repo-specific guardrails
+
+Concrete "don't reintroduce this" rules, accumulated as issues get found and fixed. Add to this list as you go — see the "Keep the specs honest" section in `CLAUDE.md`.
+
+- Don't add a third "is the user logged in" check. The existing ones are: `useSelector(selectIsLoggedIn)` (Redux only), `Cookies.get("Token") && isLoggedIn` (cookie + Redux, used by the route guard and Navbar — prefer this for new auth-gated UI), and a legacy `Cookies.get("isLoggedIn")` cookie used only by the orphaned Donate page (do not extend this one). See `docs/specs/state-management.md`.
+- Don't add a fourth logout cleanup path. `Navbar.jsx`, `Profile.jsx`, and `UserProfile.jsx` each dispatch `resetUserData()` plus a slightly different extra cleanup step (`localStorage.clear()`, `Cookies.remove("skipProfileCompletion")`, or nothing). If you touch logout, prefer consolidating into one shared helper over adding a fourth variant.
+- Don't wire new event-creation UI to `updateUserProfile`/`PATCH /user/update`. `src/components/shared/createEvent/CreateEvent.jsx` does this today by mistake (it was cloned from the profile-edit form and the endpoint was never swapped). The correct pattern — MUI date/time pickers, `useEvent` hook, real `POST /events/create` call — is `src/components/private/events/create/CreateEvents.jsx`; build from that one.
+- Don't assume `clubEndpoints.details(userName)` is club-only. It's queried for both individual and club profiles today (`Profile.jsx` uses it for `/user/:userName` and `/club/:userName` alike), despite the name.
+
+## when you're not sure which duplicate a request means
+
+See the "When two implementations exist, ask" section in `CLAUDE.md` — don't silently pick one.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,29 @@
+## Read this first
+
+Before making any change, read [docs/specs/README.md](./docs/specs/README.md) — it's the map of every feature in this codebase and how it actually works today, including what's broken, unused, or half-wired.
+Read the specific spec file for whatever you're touching, plus [docs/specs/known-issues.md](./docs/specs/known-issues.md).
+See [AGENTS.md](./AGENTS.md) for the fuller workflow around this.
+
+## When two implementations exist, ask
+
+This codebase has several places where two components or hooks do overlapping things (two profile-edit modals, two "create event" forms, two auth-validation systems, two public-profile pages — all cataloged in `known-issues.md`).
+If a request is ambiguous about which one it means ("add a field to the create-event form", "fix the profile page"), ask which one before writing code, rather than guessing or editing both.
+
+## Coding conventions for this repo
+
+These are drawn from how the *majority* of the existing code already does things — match them in new/changed code rather than introducing a third pattern:
+
+- **Imports:** prefer the `@/`, `@components/`, `@hooks/`, `@pages/`, `@redux/`, `@service/`, `@utils/`, `@styles/` aliases (defined in both `vite.config.mjs` and `jsconfig.json` — keep them in sync if you add one) over relative paths in new code.
+- **API calls:** add new backend calls to `src/service/MilanApi.js` following its existing pattern (plain `axios`, catch and return `error.response` rather than throwing, `withCredentials: true` on writes) — not the `src/integrations/*` + `ApiConnector` layer, which is only used by two dead-end helpers today. See `docs/specs/api-integration.md`.
+- **Reads inside components:** use `useSWR(endpoint, fetcher)` (from `src/utils/Fetcher.js`), matching `Dashboard.jsx`/`Profile.jsx`. Don't add new `@tanstack/react-query` usage — the provider is mounted but nothing uses it yet.
+- **Status codes:** compare against `STATUSCODE` from `src/static/Constants.js` (e.g. `STATUSCODE.OK`) rather than a bare `200`.
+- **Toasts:** use `showSuccessToast`/`showErrorToast` from `src/utils/Toasts.js` for any API-triggered feedback, not `toast.success`/`toast.error` directly — they already handle the offline case.
+- **Buttons:** use the shared `Button` component (`src/components/shared/buttons/globalbutton/Button.jsx`) and its `onClickfunction` prop, not a raw `<button onClick>`, for anything that should look like the rest of the app.
+- **Styling:** match whatever the immediate sibling files in that folder already use (plain `.scss` with BEM-ish class names is the majority pattern) — don't introduce styled-components or a new CSS Modules file into a folder that's currently all `.scss`.
+- **Validation on submit:** if you fix a form's validation, make sure a non-empty `errors` object actually blocks the API call — several existing forms compute errors but call the API anyway (see `known-issues.md`); don't copy that pattern into new code.
+
+## Keep the specs honest
+
+If you fix something `docs/specs/known-issues.md` calls out, remove that entry and update the relevant feature spec in the same change.
+If you build out something a spec marks as an unused/unwired stub (e.g. wiring `getClubs()`/`getEvents()` into the real pages, finishing `UserProfile.jsx`), update that spec to describe the new, real behavior instead of the old placeholder.
+If you notice something new and wrong while working nearby, add it to `known-issues.md` rather than leaving it undocumented.

--- a/docs/specs/README.md
+++ b/docs/specs/README.md
@@ -1,0 +1,67 @@
+# NgoWorld (Milan) Frontend — Feature Specs
+
+This directory is a map of the codebase for AI coding agents and new contributors.
+Each file documents one feature area: what it does, which files implement it, how data flows through it, and any known gaps or inconsistencies.
+These specs describe the code as it exists today, including its rough edges — they are not aspirational.
+When you change a feature, update its spec file in the same PR so this map stays trustworthy.
+
+## What this project is
+
+NgoWorld (product name "Milan", package name `milan-frontend`) is the React frontend for a platform that connects NGOs, charities, clubs, and individual users.
+It talks to a separate backend repo, [NgoWorld-Backend](https://github.com/ngoworldcommunity/NGOWorld-Backend), over a REST API.
+There is no server-side code in this repo — it is a Vite + React SPA.
+
+## Tech stack
+
+- **React 19** with `react-router-dom` v7 for routing (`BrowserRouter`, all routes rendered in [App.jsx](../../src/App.jsx)).
+- **Vite** as the build tool, with `vite-plugin-pwa` for PWA/service-worker support and `vite-plugin-svgr` for importing SVGs as components.
+- **Redux Toolkit + redux-persist** for the logged-in user's profile/session data (persisted to `localStorage`).
+- **Zustand** for one small piece of ephemeral UI state — a global `isLoading` flag (see [state-management.md](./state-management.md)).
+- **SWR** (`useSWR`) for server-state fetching/caching in most read paths; a few older call sites use raw `axios` in `useEffect` instead.
+- **`@tanstack/react-query`**'s `QueryClientProvider` wraps the whole app but is not actually used by any query hooks yet — see [known-issues.md](./known-issues.md).
+- **MUI** (`@mui/material`, `@mui/x-date-pickers`) for the event-creation date/time pickers and a few form controls.
+- **styled via CSS Modules / SCSS / plain CSS**, inconsistently, per component — see [ui-kit.md](./ui-kit.md).
+- **Cypress** for end-to-end tests (`cypress/e2e/milanTest.spec.js`), currently a minimal smoke test.
+
+## Path aliases
+
+Both `vite.config.mjs` and `jsconfig.json` define the same aliases; keep them in sync when adding a new one.
+
+| Alias | Resolves to |
+|---|---|
+| `@/*` | `src/*` |
+| `@components/*` | `src/components/*` |
+| `@hooks/*` | `src/hooks/*` |
+| `@pages/*` | `src/pages/*` |
+| `@redux/*` | `src/redux/*` |
+| `@service/*` | `src/service/*` |
+| `@utils/*` | `src/utils/*` |
+| `@styles/*` | `src/styles/*` |
+
+Much of the older code still uses relative imports (`../../components/shared`) instead of these aliases.
+Both styles coexist; prefer the alias style in new code.
+
+## Feature map
+
+| Spec | Covers |
+|---|---|
+| [architecture.md](./architecture.md) | App shell, routing table, providers, build config |
+| [state-management.md](./state-management.md) | Redux store/slice, Zustand store, redux-persist, cookies |
+| [api-integration.md](./api-integration.md) | Every way the frontend talks to the backend: `MilanApi.js`, `integrations/*`, `ApiConnector`, SWR fetchers |
+| [authentication.md](./authentication.md) | Sign in, sign up, Google OAuth, logout, route guarding, password/email validation |
+| [onboarding-profile.md](./onboarding-profile.md) | Post-signup profile completion, profile editing, the public Profile/UserProfile pages |
+| [dashboard.md](./dashboard.md) | The logged-in club/org dashboard |
+| [clubs.md](./clubs.md) | The Clubs directory page and `ClubCard` |
+| [events.md](./events.md) | Events listing, event creation modal(s), event cards/slider |
+| [landing-home.md](./landing-home.md) | Home page, marketing Landing hero, `MilanInfoBanner` |
+| [layout-navigation.md](./layout-navigation.md) | Navbar, Footer, Header, Modal, Loading, BackToTop, page `<Helmet>` usage |
+| [ui-kit.md](./ui-kit.md) | Shared `Button`, `AuthButton`, card components, and the styling conventions behind them |
+| [donate-shop-trending.md](./donate-shop-trending.md) | Donate (Razorpay), Shop and Trending "coming soon" placeholders |
+| [error-handling.md](./error-handling.md) | 404 page, toast conventions, `Test.jsx` |
+| [known-issues.md](./known-issues.md) | Cross-cutting bugs, dead code, and inconsistencies found while writing these specs — read this before touching adjacent code |
+
+## How to use this with an AI agent
+
+Point the agent at the spec for the feature it is changing, plus [architecture.md](./architecture.md) and [state-management.md](./state-management.md) for shared context.
+The specs name the real backend endpoints each feature calls (see [api-integration.md](./api-integration.md)) — the backend repo is the source of truth for request/response shapes, not this repo.
+Where a spec calls out a bug or a stub component, treat that as authoritative unless you've just fixed it — then update the spec.

--- a/docs/specs/api-integration.md
+++ b/docs/specs/api-integration.md
@@ -1,0 +1,66 @@
+# API Integration Layer
+
+All backend calls target one base URL, `import.meta.env.VITE_API_URL`, with no trailing-slash normalization — endpoint builders assume `VITE_API_URL` has no trailing slash.
+There is no backend code in this repo; the backend is [NgoWorld-Backend](https://github.com/ngoworldcommunity/NGOWorld-Backend), and that repo is the source of truth for actual request/response payload shapes.
+Everything below documents how the *frontend* calls it, not what the backend guarantees.
+
+## Two parallel call layers
+
+This is the single most important thing to know before adding a new API call: there are two different, uncoordinated ways calls are made.
+
+### Layer A — `src/service/MilanApi.js` (the one almost everything uses)
+
+Plain `axios` calls (imported directly as `Axios`, not through `ApiConnector`).
+Each function catches errors and returns `error.response` (or `error` itself in a couple of functions) instead of throwing — callers must check `response?.status` rather than using `try/catch`.
+Functions exported: `LoginUser`, `RegisterUser`, `GetAllClubs`, `ReportProblem`, `completeProfileApiCall`, `updateUserProfile`, `GoogleAuth`, `successCallback`, `Logout`, `CreateEvent`, `fetchDashboard`.
+Most POST/PATCH calls pass `{ withCredentials: true }` so the backend's session/auth cookie is sent; a few reads (`GetAllClubs`) don't.
+
+### Layer B — `src/integrations/*.js` (only used for read-only club/event listing helpers)
+
+Goes through [ApiConnector.js](../../src/integrations/ApiConnector.js), a thin wrapper around a separate `axios.create({})` instance (`axiosInstance`), exposing `apiConnector(method, url, bodyData, headers, params)`.
+Only two consumers exist: `getClubs()` in [Clubs.js](../../src/integrations/Clubs.js) and `getEvents()` in [Events.js](../../src/integrations/Events.js) — and neither of those two functions is actually called anywhere in the app; `Clubs.jsx` and `Events.jsx` (the pages) both currently render hardcoded demo arrays instead.
+See [known-issues.md](./known-issues.md).
+`ApiConnector`'s dead status-600 check (`if (response.status === 400) console.error("Logout triggered due to status 600 response")`) is unreachable — `response.status === 400` never equals `600`, and axios throws (doesn't return) on 4xx/5xx by default anyway, so this branch is unreachable through the normal success path.
+
+**When adding a new call, follow Layer A's pattern** (`MilanApi.js` + direct `axios`) unless you're specifically building on top of the existing `getClubs`/`getEvents` read helpers.
+
+## Endpoint registry — `src/integrations/ApiEndpoints.js`
+
+All endpoint URL strings/builders live here, grouped by domain, and are imported by both layers above.
+
+```js
+userEndpoints:  details(userName), profile, update, report, completeProfile, updateProfile
+clubEndpoints:  all, details(userName), createEvent, dashboard
+eventEndpoints: all, create
+authEndpoints:  signin, signup, googleLogin, googleLoginSuccess, logout
+```
+
+Note `userEndpoints.update` and `userEndpoints.updateProfile` both exist and point to different URLs (`/user/update/profile` vs `/user/update`) — only `updateProfile` is actually referenced (`ProfileUpdate.jsx`/`useValidation`-adjacent flows).
+`clubEndpoints.details(userName)` is queried with `?userName=` but is used for both individual users and clubs (see [onboarding-profile.md](./onboarding-profile.md) — `Profile.jsx` calls `clubEndpoints.details` even on the `/user/:userName` route).
+
+## SWR usage (data fetching in components)
+
+`useSWR(key, fetcher, options)` is the dominant pattern for GET requests inside components.
+Two fetcher functions exist:
+- [src/utils/Fetcher.js](../../src/utils/Fetcher.js) — `axios.get(url, { withCredentials: true }).then(res => res.data)`. Used almost everywhere.
+- [src/utils/fetchers/PatchFetcher.js](../../src/utils/fetchers/PatchFetcher.js) — same shape but issues a PATCH. Not currently imported by any component (dead file) — SWR mutations in this app instead call the relevant `MilanApi.js` function directly and then call `mutate()`.
+
+SWR call sites:
+| Component | Key | Purpose |
+|---|---|---|
+| `Dashboard.jsx` | `userEndpoints.profile` | Loads the logged-in club/org's own profile; `onSuccess` re-syncs Redux |
+| `Profile.jsx` | `clubEndpoints.details(userName)` | Loads a public profile by username, for both `/user/:userName` and `/club/:userName` |
+| `UserProfile.jsx` | `userEndpoints.details(slug)` | Loads a public profile by slug (a second, mostly-unused profile page — see [onboarding-profile.md](./onboarding-profile.md)) |
+
+`useEvent.js`'s `submitCallback` calls `mutate(eventEndpoints.all)` from `useSWRConfig()` after a successful event creation, to invalidate any cached `eventEndpoints.all` SWR key — but no component currently fetches `eventEndpoints.all` via SWR, so this revalidation currently has no listener.
+
+## Status codes and messages
+
+[src/static/Constants.js](../../src/static/Constants.js) exports `STATUSCODE` (a full HTTP status-code map) and `STATUSMESSAGE` (a set of canned backend message strings).
+`STATUSCODE.OK` is used in a handful of places (`useProfileCompletion.js`, `ProfileUpdate.jsx`, `CreateEvent.jsx`) to check `data.status === STATUSCODE.OK`; most other call sites just compare raw numbers (`response?.status === 201 || response?.status === 200`) inline instead of using the constant — prefer `STATUSCODE` in new code for consistency.
+`STATUSMESSAGE` values don't appear to be read anywhere in the frontend; toasts display whatever message string the backend response includes (`response?.data?.message`), so this constant is effectively documentation of expected backend messages rather than live code.
+
+## Toast conventions
+
+All user-facing success/error feedback for API calls goes through [showSuccessToast / showErrorToast](../../src/utils/Toasts.js) (react-toastify), which both no-op (return early) if `checkInternetConnection()` reports the browser is offline.
+Follow this pattern for any new API-triggered feedback rather than calling `toast.success`/`toast.error` directly.

--- a/docs/specs/architecture.md
+++ b/docs/specs/architecture.md
@@ -1,0 +1,76 @@
+# Architecture
+
+## Entry point and providers
+
+[src/index.jsx](../../src/index.jsx) is the actual entry point (see `index.html`).
+It mounts `<App />` inside, from outermost to innermost: Redux `<Provider>`, `<HelmetProvider>` (for per-page `<title>`/meta tags via `react-helmet-async`), and redux-persist's `<PersistGate>`.
+`<Analytics />` and `<SpeedInsights />` from Vercel are rendered as siblings of `<App />`, so they run regardless of route.
+It also sets a `--vh` CSS custom property from `window.innerHeight` on load, a common mobile-viewport-height workaround; it is not recalculated on resize.
+
+[src/App.jsx](../../src/App.jsx) wraps the router in `<QueryClientProvider>` (from `@tanstack/react-query`) and MUI's `<LocalizationProvider>` (needed for the date/time pickers used in event creation).
+It renders a global `<ToastContainer />` (react-toastify) and a global `<BacktoTop />` button outside the `<Routes>`, so both appear on every page.
+Route content is wrapped in `<Suspense fallback={"Loading . . ."}>` to support the two lazy-loaded auth pages (see below).
+
+Note: `QueryClientProvider` is set up but no component in the codebase currently calls `useQuery`/`useMutation` — all server-state fetching goes through SWR or plain `axios` instead.
+See [known-issues.md](./known-issues.md).
+
+## Routing
+
+The route table lives in [src/utils/routesConfig.jsx](../../src/utils/routesConfig.jsx) and is consumed by `App.jsx`, which maps it into a flat list of `<Route>` elements (no nested routes, no layout routes).
+
+| Path | Element | Notes |
+|---|---|---|
+| `/` | `Home` | Landing page + marketing content |
+| `/auth/signup` | `SignUp` (lazy, wrapped in `DonotRenderWhenLoggedIn`) | |
+| `/auth/signin` | `SignIn` (lazy, wrapped in `DonotRenderWhenLoggedIn`) | |
+| `/user/:userName` | `Profile` | Individual-user public profile |
+| `/clubs` | `Clubs` | Club/org directory |
+| `/club/:userName` | `Profile` | Club public profile — reuses the same `Profile` component as `/user/:userName` |
+| `/dashboard` | `Dashboard` | Logged-in club/org's own dashboard |
+| `/events` | `Events` | Event directory |
+| `/shop` | `Shop` | "Coming soon" placeholder |
+| `/trending` | `Trending` | "Coming soon" placeholder |
+| `*` | `Error404` | Catch-all |
+
+`SignIn` and `SignUp` are the only lazily-loaded routes (`lazy(() => import(...))`), and are each wrapped by [DonotRenderWhenLoggedIn](../../src/utils/Auth/DonotRenderWhenLoggedIn.jsx) — a HOC that redirects an already-authenticated user to `/`.
+See [authentication.md](./authentication.md).
+
+Pages are exported from a barrel file, [src/pages/route.js](../../src/pages/route.js), and re-exported under friendlier names (`Login` for `SignIn`, etc.).
+`routesConfig.jsx` imports most pages from this barrel but imports `Home` and `Trending` directly — there's no functional difference, just inconsistent style.
+
+There is no `/donate` route registered anywhere, even though `src/pages/donate/Donate.jsx` exists.
+There is no `/events/:id` (or similar) detail route either, even though `src/pages/events/detailed/DetailedEvent.jsx` exists as a stub.
+Both are effectively unreachable dead code today — see [known-issues.md](./known-issues.md).
+
+## Build configuration
+
+- `vite.config.mjs` configures the path aliases (see [README.md](./README.md)), dev server (`port: 3000`, `host: true`, `usePolling: true` for the watcher — relevant in Docker/WSL setups), and `vite-plugin-pwa` with a `CacheFirst` runtime-caching strategy for Google Fonts and image files.
+- Environment variables are read via `import.meta.env.*` and must be prefixed `VITE_`.
+  The two names actually read in code are `VITE_API_URL` (base URL for every backend call) and `VITE_RAZORPAY_KEY_ID` (see [donate-shop-trending.md](./donate-shop-trending.md)).
+  `.env.example` at the repo root documents `VITE_MILANAPI` instead of `VITE_API_URL` — that's a stale variable name; see [known-issues.md](./known-issues.md).
+- `eslint.config.js` and `.prettierrc` define lint/format rules; `husky` + `lint-staged` run `eslint --fix` and `prettier --write` on staged `.js`/`.jsx` files pre-commit.
+- `commitlint.config.js` enforces Conventional Commits via a husky `commit-msg` hook.
+
+## Directory layout
+
+```
+src/
+  App.jsx, index.jsx          — app shell / bootstrap
+  pages/                      — one folder per route/page (see routesConfig.jsx)
+  components/
+    shared/                   — reusable across public + private pages (Navbar, Footer, Button, cards, modals...)
+    private/                  — used only behind auth-gated pages (dashboard sections, event creation, landing)
+  redux/                      — Redux Toolkit store + userSlice
+  store/                      — Zustand store (useAuth — loading flag only)
+  hooks/                      — useAuth, useEvent, useFormLogic, useProfileCompletion, useValidation
+  service/                    — MilanApi.js (most backend calls), PaymentGateway.js (Razorpay)
+  integrations/               — ApiConnector.js (axios wrapper), ApiEndpoints.js (URL builders), Clubs.js, Events.js
+  utils/                      — cross-cutting helpers (toasts, fetchers, formatting, auth HOC/toggles)
+  static/                     — static reference data (Constants.js, CountryList.js, OnlinePlatform.js)
+  constants/                  — ProfileElements.js (form-field metadata)
+  styles/                     — global CSS/SCSS
+  assets/                     — images, SVGs
+```
+
+Two backend-call layers coexist: `src/service/MilanApi.js` (raw `axios`, most calls) and `src/integrations/*.js` (goes through `ApiConnector.js`, only used by `getClubs`/`getEvents`).
+See [api-integration.md](./api-integration.md) for which one each feature actually uses.

--- a/docs/specs/authentication.md
+++ b/docs/specs/authentication.md
@@ -1,0 +1,63 @@
+# Authentication
+
+Covers sign in, sign up, Google OAuth, logout, and the route guard that keeps logged-in users off the auth pages.
+For where the resulting session state is stored, see [state-management.md](./state-management.md).
+
+## Pages
+
+- [src/pages/auth/SignIn.jsx](../../src/pages/auth/SignIn.jsx) — email + password form.
+- [src/pages/auth/SignUp.jsx](../../src/pages/auth/SignUp.jsx) — name + email + password form, plus an "Individual" vs "Organization" (`userType`) toggle built with `react-select` (desktop label: "Account Type" dropdown) and a separate custom checkbox-styled toggle (the `.status-switch` div) on the right-hand panel — two different UI controls that both flip the same `userType` state, shown at different breakpoints.
+- Both pages share `./index.scss` and mount `<Navbar />` at the top but no `<Footer />`.
+- Both are lazy-loaded in [routesConfig.jsx](../../src/utils/routesConfig.jsx) and wrapped in `DonotRenderWhenLoggedIn` (see below).
+
+## The `useAuth` hook
+
+[src/hooks/useAuth.js](../../src/hooks/useAuth.js) is the single entry point both pages call: `useAuth("signin")` or `useAuth("signup")`.
+It returns `{ authenticateUser, loading }`.
+
+`authenticateUser(credentials, setErrors)` does, in order:
+1. Bails out (no-op) if `checkInternetConnection()` reports offline.
+2. Validates `credentials.email` against `emailRegex` from `static/Constants.js`. On failure, sets a field-level error via `setErrors` and returns — **this also runs on sign-in**, not just sign-up.
+3. Validates `credentials.password` against an inline regex requiring 8+ chars, at least one digit, one lowercase, one uppercase letter. Same behavior: applies on sign-in too, so an existing user whose password predates this rule (or simply doesn't match the pattern for a `signin` typo) will get a client-side "password" error even though the backend would have rejected it anyway. This client check happens before any network call is made.
+4. Sets `loading = true`, then calls `LoginUser(credentials)` or `RegisterUser({ ...credentials, userType: credentials.userType.value })` from `MilanApi.js`. Note `userType` is only unwrapped from its `react-select` `{value, label}` shape for sign-up.
+5. On `response.status` 200/201: shows a success toast, dispatches `updateUserData({ ...response.data.user, isLoggedIn: true })` to Redux, then after a fixed 1000ms `setTimeout`, navigates to `/` and clears `loading`.
+6. Otherwise: shows an error toast with `response?.data?.message` and clears `loading`.
+
+Both `SignIn` and `SignUp` disable their submit `<Button>` while `loading` is true or while any required field is empty, and show a `ClipLoader` spinner via the shared `Button` component's `isLoading` prop.
+
+## Field-level validation display
+
+Neither page uses [useValidation.js](../../src/hooks/useValidation.js) — that hook is a much more thorough validator (see below) that's actually wired into [useFormLogic.js](../../src/hooks/useFormLogic.js), a hook that no page currently calls (see [known-issues.md](./known-issues.md)).
+`SignIn`/`SignUp` instead just render whatever `errors.email`/`errors.password` the two checks inside `useAuth.authenticateUser` set, directly under each input as a `<p>`.
+
+## `useValidation.js` and `useFormLogic.js` (currently unused by any page)
+
+[src/hooks/useValidation.js](../../src/hooks/useValidation.js) is a much richer form validator supporting both an "individual" signup shape and a "club" signup shape (name/tagline/description length bounds, slug format rules, address/pincode checks, website URL format).
+It returns an array of `{ error, message, field }` objects, or `{ error: false, message: "" }` if clean.
+[src/hooks/useFormLogic.js](../../src/hooks/useFormLogic.js) wraps a generic submit handler around this validator, driven by the Zustand `isLoading` flag, and exports two ready-made initial-state shapes: `individualInitialFormState` and `clubInitialFormState`.
+Together these look like the intended, more complete signup flow (with club-specific fields like `tagLine`) — but `SignUp.jsx` does not use either of them today.
+Treat this pair as the design to converge toward if you're asked to build out full club-signup fields, not as dead code to delete without checking with the team first.
+
+## Google OAuth
+
+`handleGoogle()` on both auth pages calls `GoogleAuth()` (`MilanApi.js`, `GET /auth/google`) and full-page-redirects (`window.location.href = response`) to the URL the backend returns.
+The backend is expected to redirect back to the frontend after auth and set an `OAuthLoginInitiated` cookie; [Home.jsx](../../src/pages/Home.jsx) checks for that cookie on mount and, if present, calls `successCallback()` (`GET /auth/login/success`) to fetch the now-authenticated user and dispatch `updateUserData(...)` + `toggleUserLogin()` into Redux.
+This means a Google sign-in only "completes" on the frontend if the user lands back on `/` — landing anywhere else after the OAuth redirect would skip this step.
+
+## Logout
+
+`Logout()` (`MilanApi.js`, `GET /auth/logout`) is called from three places with three slightly different cleanup sequences: `Navbar.jsx`, `Profile.jsx`, and `UserProfile.jsx`.
+All three dispatch `resetUserData()` on success; `Navbar.jsx` additionally calls `localStorage.clear()`, `Profile.jsx` additionally calls `Cookies.remove("skipProfileCompletion")`, and `UserProfile.jsx` does neither extra step but does toggle the Zustand `isLoading` flag around the call.
+There is no shared `useLogout()` hook — consider extracting one if you need to touch this again, so the cleanup steps stay consistent.
+
+## Route guard: `DonotRenderWhenLoggedIn`
+
+[src/utils/Auth/DonotRenderWhenLoggedIn.jsx](../../src/utils/Auth/DonotRenderWhenLoggedIn.jsx) is a HOC (`DonotRenderWhenLoggedIn(Component)`) applied to `SignIn` and `SignUp` in `routesConfig.jsx`.
+It redirects to `/` (`<Navigate to="/" />`) if both `Cookies.get("Token")` and the Redux `isLoggedIn` selector are truthy; otherwise it renders the wrapped component.
+It does not protect any other route — there is currently no equivalent "require login" guard for e.g. `/dashboard`, which is reachable by URL regardless of auth state (pages that need a logged-in user instead fetch data scoped to the session cookie and render whatever comes back, including nothing).
+
+## Small auth-adjacent utilities
+
+- [PasswordToggle.js](../../src/utils/Auth/PasswordToggle.js) exports `passwordToggle`/`confirmPasswordToggle`, simple `"password" ↔ "text"` togglers for an input's `type`. Not currently used by `SignIn`/`SignUp` — those pages inline their own `showPassword` state and swap `FaEye`/`FaEyeSlash` icons directly instead.
+- [RenderErrorMessage.jsx](../../src/utils/Auth/RenderErrorMessage.jsx) exports `renderErrorMessage(fieldName, formState)`, meant to render all `formState.errors` matching a given field (the shape `useValidation.js` produces). Only meaningful once a page adopts `useValidation`/`useFormLogic`; not used by the current `SignIn`/`SignUp`.
+- [AuthButton.jsx](../../src/components/shared/buttons/authbutton/AuthButton.jsx) is a reusable "Sign In ⇄ Sign Up" submit button + toggle link that infers which mode it's in from `window.location.pathname`. Not currently rendered by `SignIn.jsx`/`SignUp.jsx` (they build their own submit button and toggle link inline) — it appears to be an earlier version of the same UI.

--- a/docs/specs/clubs.md
+++ b/docs/specs/clubs.md
@@ -1,0 +1,21 @@
+# Clubs
+
+The clubs directory, routed at `/clubs`.
+
+## `Clubs.jsx`
+
+[src/pages/clubs/Clubs.jsx](../../src/pages/clubs/Clubs.jsx).
+Renders `<ComponentHelmet type="Clubs" />` (SEO title/meta — see [layout-navigation.md](./layout-navigation.md)), `<Navbar />`, a search input + "Filters" button (both non-functional — no `onChange`/`onClick` wired), a "Your Dashboard" button that navigates to `/dashboard`, a grid of `<ClubCard />`, and `<Footer />`.
+
+**The club list is entirely hardcoded**: `clubs = Array.from({ length: 20 }, () => ({ _id: "673ac2814c6e89e58af8ca11", userType: "club", userName: "tamalcodes", name: "God Father Org", ... }))` — 20 identical fake club objects, not a fetch.
+The real data-fetching function, `getClubs()` in [src/integrations/Clubs.js](../../src/integrations/Clubs.js) (`GET /clubs` via `clubEndpoints.all`), exists but is never called by this page.
+When asked to make this page live, wire `getClubs()` (or a new SWR call against `clubEndpoints.all`) in here instead of building a new fetch path — see [api-integration.md](./api-integration.md) for the two-layer call-pattern context.
+
+The `Loading` fallback (`!clubs || clubs?.length === 0`) can currently never trigger, since `clubs` is always a populated hardcoded array.
+
+## `ClubCard`
+
+[src/components/shared/cards/club/ClubCard.jsx](../../src/components/shared/cards/club/ClubCard.jsx).
+Presentational card: banner image (always the same static `clubbanner.jpg` asset, regardless of the club passed in — there's no per-club image field consumed), `club?.name`/`club?.description` with hardcoded fallback text, static follower/event counts (not derived from the `club` prop), and a link to `/club/{club?.userName}` (which resolves to `Profile.jsx` — see [onboarding-profile.md](./onboarding-profile.md)).
+
+Exported from the shared barrel: `src/components/shared/index.js`.

--- a/docs/specs/dashboard.md
+++ b/docs/specs/dashboard.md
@@ -1,0 +1,36 @@
+# Dashboard
+
+Routed at `/dashboard`, reachable by URL to any visitor regardless of auth state (no route guard — see [authentication.md](./authentication.md)); in practice it only shows meaningful data when the session cookie belongs to a club/org account.
+
+## `Dashboard.jsx`
+
+[src/pages/dashboard/Dashboard.jsx](../../src/pages/dashboard/Dashboard.jsx).
+
+- Fetches the logged-in account's own profile via SWR: `useSWR(userEndpoints.profile, fetcher, { onSuccess, onError })`.
+  `onSuccess` dispatches `updateUserData(data?.user)` to Redux on every successful fetch/revalidation, keeping Redux in sync with the server.
+  `onError` shows an error toast with `error?.response?.data?.message`.
+- Renders a cover image and profile picture — both are hardcoded stock photo URLs (Pexels/other CDN), not derived from `profileData` at all.
+- Renders static follower/event counts (`1.25k` / `231`) — not derived from `profileData` either; these are placeholder numbers.
+- An "Edit Profile" `<button>` opens `ProfileUpdate` (`setOpenModal(true)`), first calling `handleSetDefaultValues(profileData?.user)` from `useProfileCompletion` to pre-populate the form.
+- Renders `profileData?.user?.name` and `profileData?.user?.description` (these two *are* real, live data).
+- Conditionally renders `ProfileCompletion` when `profileData?.user?.config?.hasCompletedProfile === false`, and `ProfileUpdate` when `openModal === true` — see [onboarding-profile.md](./onboarding-profile.md) for both components' behavior.
+- Renders `<TrackSection />` inside a `.dashboard_track` block labeled "Real time Analytics — Coming Soon".
+
+There's a stray `console.log(profileData?.user)` in the "Edit Profile" click handler — remove it if you're in this file for another reason.
+
+## `TrackSection`
+
+[src/components/private/dashboard/TrackSection.jsx](../../src/components/private/dashboard/TrackSection.jsx).
+Purely presentational analytics widget: a 7D/14D/28D tab row (only "7D" is styled active; clicking the others does nothing — no `onClick` handlers), and two static stat boxes ("Impressions: 6,025", "Click Rate: 43%").
+A "See detailed analytics" link points to `/` (home), not a real analytics page.
+Matches the "Coming Soon" framing in `Dashboard.jsx` — this is intentionally a visual placeholder, not wired to `fetchDashboard()` (see below) despite that function existing.
+
+## `fetchDashboard` (defined, unused)
+
+[MilanApi.js](../../src/service/MilanApi.js) exports `fetchDashboard()` (`GET /clubs/dashboard`, via `clubEndpoints.dashboard`).
+No component currently calls it — `Dashboard.jsx` fetches `userEndpoints.profile` instead.
+If you're asked to wire up real dashboard analytics, this is the endpoint that was evidently intended for it.
+
+## `ProfileSection` (empty stub)
+
+[src/components/private/dashboard/ProfileSection.jsx](../../src/components/private/dashboard/ProfileSection.jsx) is a one-line placeholder (`<div>ProfileSection</div>`) and is not imported by `Dashboard.jsx` or anywhere else.

--- a/docs/specs/donate-shop-trending.md
+++ b/docs/specs/donate-shop-trending.md
@@ -1,0 +1,25 @@
+# Donate, Shop & Trending
+
+Three low-priority/incomplete areas grouped together because none of them represent a finished feature today.
+
+## Donate (currently unroutable)
+
+[src/pages/donate/Donate.jsx](../../src/pages/donate/Donate.jsx) exists but **has no entry in `routesConfig.jsx`** — it cannot be reached by navigating the live app.
+It also imports two components that no longer exist in the current file tree: `../../components/Cards/SingleClubEvent/SingleClubEvent` and `../../components/Loading` (the real `Loading` component now lives at `src/components/shared/loading/Loading.jsx`, exported from the shared barrel).
+**Importing this file today will fail the build** — it is stale code from before a component reorganization, not a working feature.
+It fetches clubs via `GetAllClubs()` (`MilanApi.js`, `GET /clubs`), loads the Razorpay checkout script (`https://checkout.razorpay.com/v1/checkout.js`) via a hand-rolled `loadScript` helper, and gates access on `Cookies.get("isLoggedIn")` — a cookie that, per [state-management.md](./state-management.md), is not set anywhere else in the current codebase (the rest of the app uses the `Token` cookie + Redux `isLoggedIn`), so this gate can never pass today even if the imports were fixed.
+
+If asked to "fix the donate page," treat this as a near-full rewrite (fix imports, register a route, align the login-gate check with the rest of the app) rather than a small patch — confirm scope before starting.
+
+## `PaymentGateway.js` (Razorpay integration — the working piece)
+
+[src/service/PaymentGateway.js](../../src/service/PaymentGateway.js) exports `displayRazorpay(money)`, the one part of the donate flow that is self-contained and functional in isolation: it `POST`s to `/payment/razorpay` with `{ amount: money }`, then opens Razorpay's checkout widget (`window.Razorpay`) configured with `VITE_RAZORPAY_KEY_ID`.
+Its `prefill` block hardcodes the app author's own name/email/phone (`Tamal Das`, `tamalcodes@gmail.com`, a phone number) rather than the logged-in user's details — replace this with real user data before this ships to real donors.
+Its success `handler` only shows a thank-you toast; it doesn't confirm the payment with the backend or update any order/donation record client-side (that's presumably handled server-side via Razorpay webhooks, but there's nothing in this repo to verify that).
+Not currently imported by any component (since `Donate.jsx` can't build) — the Razorpay checkout script itself is loaded separately, by `Donate.jsx`'s own `loadScript` call, not by this file.
+
+## Shop and Trending — intentional placeholders
+
+[src/pages/shop/Shop.jsx](../../src/pages/shop/Shop.jsx) (routed `/shop`) and [src/pages/Trending.jsx](../../src/pages/Trending.jsx) (routed `/trending`) are both thin wrappers around the shared `<ComingSoon />` component — see [src/components/shared/comingSoon/ComingSoon.jsx](../../src/components/shared/comingSoon/ComingSoon.jsx).
+`ComingSoon` takes a `launchitem` string (e.g. `"shop's page."`, `"Trending section"`) and renders a static illustration, a heading, and a "Sign up to get notified" CTA linking to `/auth/signup`.
+These two pages are deliberately unfinished — unlike Donate, there is no broken/dead code here to fix, just no feature built yet.

--- a/docs/specs/error-handling.md
+++ b/docs/specs/error-handling.md
@@ -1,0 +1,23 @@
+# Error Handling & Misc Pages
+
+## 404
+
+[src/pages/error/Error404.jsx](../../src/pages/error/Error404.jsx), matched by the `*` catch-all route in `routesConfig.jsx`.
+Renders a static SVG illustration and a `Button` (`to="/"`) back to home.
+No `<Helmet>`/SEO tags, unlike most other top-level pages — worth adding if you touch this file.
+
+## API/network error feedback
+
+There is no error boundary (`componentDidCatch`/React error boundary) anywhere in the app — an uncaught render error in any component will produce a blank white screen with no fallback UI.
+Network/API errors are instead surfaced per-call via toasts — see [Toasts.js conventions](./api-integration.md#toast-conventions) and [checkInternetConnection.js](../../src/utils/CheckInternetConnection.js), which suppresses all toasts (success and error alike) whenever `navigator.onLine === false`, on the assumption that an offline banner would be more useful than a flood of failed-request toasts (no such offline banner currently exists, though — the user just sees nothing).
+
+## `Test.jsx` (dev leftover, currently routed)
+
+[src/pages/Test.jsx](../../src/pages/Test.jsx) is **not** wired into `routesConfig.jsx`, so it isn't reachable via any path, but it does still exist in the tree: on mount it immediately redirects the browser to `https://www.google.com`.
+Almost certainly a debugging scratch file — safe to delete unless someone confirms otherwise, but flag it rather than silently removing it if you weren't specifically asked to clean up dead files.
+
+## Cypress E2E
+
+`cypress/e2e/milanTest.spec.js` is the only spec file and is a minimal smoke test.
+`cypress/support/commands.js` and `e2e.js` are the default Cypress scaffolding, largely unmodified.
+There is no CI-side unit test runner configured (no `test` script in `package.json`); Cypress (`npm run cypress:open` / `cypress:run`) is the only automated test tooling in this repo today.

--- a/docs/specs/events.md
+++ b/docs/specs/events.md
@@ -1,0 +1,57 @@
+# Events
+
+Covers the events directory page, the (two, redundant) event-creation modals, and the various event card/slider components.
+
+## `Events.jsx` — routed at `/events`
+
+[src/pages/events/all/Events.jsx](../../src/pages/events/all/Events.jsx).
+Renders `<ComponentHelmet type="Clubs" />` (note: passes `"Clubs"`, not `"Events"`, so it shows the Clubs SEO copy — likely a copy-paste bug; `ComponentHelmet` does have an `"Events"` branch, see [layout-navigation.md](./layout-navigation.md)), `<Navbar />`, a search input + non-functional "Filters" button, a "Create An Event" button that opens the creation modal, `<EventSlider />` (featured events carousel), a grid of `<EventCard />`, and `<Footer />`.
+
+**The event list is hardcoded**, same pattern as `Clubs.jsx`: 20 identical fake objects (which are actually shaped like *user/club* records, not event records — `{ _id, userType, userName, name, email, password, cart, __v }` — copy-pasted from the `Clubs.jsx` demo data and not updated).
+`EventCard` doesn't even read the `event` prop it's passed (see below), so this mismatch is currently invisible.
+The real fetcher, `getEvents()` in [src/integrations/Events.js](../../src/integrations/Events.js) (`GET /events` via `eventEndpoints.all`), exists but is never called here.
+
+The "Create An Event" button opens `CreateEvent` from `@components/shared/createEvent/createEvent` — note the lowercase-`c` import path (`createEvent.jsx` doesn't exist; the real file is `CreateEvent.jsx`).
+This resolves correctly only because most filesystems Vite runs on (macOS default, most CI/Linux configured case-insensitively via bundler resolution... actually Linux is case-sensitive) — **this import is a real risk of breaking on a case-sensitive filesystem/CI runner**; see [known-issues.md](./known-issues.md).
+
+## Two different "create event" components (pick carefully)
+
+There are **two separate, differently-implemented "create an event" modals** in this codebase, and they are used in different places:
+
+### `CreateEvent` (shared, used by `Events.jsx`)
+[src/components/shared/createEvent/CreateEvent.jsx](../../src/components/shared/createEvent/CreateEvent.jsx).
+A generic dropzone-based form (cover image preview, name, description with a 500-char counter, contact number/email, an "Online"/"Offline" radio-style mode picker, and address line1/line2/city/state/country/pincode inputs) — structurally identical to `ProfileUpdate.jsx`/`ProfileCompletion.jsx`, reusing the same CSS class naming convention (`createevent_*`).
+Its `validateForm()` calls **`updateUserProfile(...)`** (`PATCH /user/update`), not an event-creation endpoint — this form does not actually create an event; it patches the user's own profile with whatever was typed into the "event" fields.
+This looks like `ProfileUpdate.jsx` was duplicated as a starting point for event creation and the API call was never swapped out.
+Several address-block inputs bind to the wrong `credentials.address.*` keys (e.g. the "City"/"State" row and the "Address Line 1/2" row both read/write `line1`/`line2` instead of `city`/`state` — copy-paste from the row above them).
+Treat this component as **not functional** for its stated purpose; if asked to fix event creation from `/events`, the more complete implementation to build from is `CreateEvents` (below), not this one.
+
+### `CreateEvents` (private, used by the events dashboard flow)
+[src/components/private/events/create/CreateEvents.jsx](../../src/components/private/events/create/CreateEvents.jsx).
+A much more complete, MUI-based form: event name, MUI `DatePicker`/`TimePicker` (via `dayjs`) for start/end date+time, an event-mode `<Select>` (Online/Offline), a unique event ID (`uid`) field, description, a cover-image upload converted to base64 via [convertToBase64.js](../../src/utils/convertToBase64.js), and mode-dependent accordion sections: Offline shows city/state/address/country (`<Select>` populated from [static/CountryList.js](../../src/static/CountryList.js))/map-iframe fields; Online shows a platform `<Select>` (populated from [static/OnlinePlatform.js](../../src/static/OnlinePlatform.js): Zoom/Google Meet/Microsoft Teams/etc., each with an icon) and a platform-link field.
+Validation and submission go through the [useEvent](../../src/hooks/useEvent.js) hook (see below), which does call the real `CreateEvent` API function (`MilanApi.js`, `POST /events/create`).
+This component is not currently rendered from anywhere reachable in the app — it lives under `components/private/events/create/` but no page imports it.
+
+**If asked to "add event creation," clarify which of these two the request means** — they are unrelated implementations that happen to share a similar name.
+
+## `useEvent` hook
+
+[src/hooks/useEvent.js](../../src/hooks/useEvent.js) — pairs with `CreateEvents` (the MUI one, not `CreateEvent`).
+`validateEvent()` checks all required fields are present (name, uid, description, coverImage, mode, start/end date+time, plus mode-specific fields), then separately checks `name` length (10–80), `description` length (20–200), and that `endDate >= startDate` / `endTime >= startTime`.
+Note: the length/date-order checks run unconditionally, even if the earlier required-field checks already populated `errors` for a different reason, and even when `data.name`/`data.description` are empty strings (`"".length < 10` is true, so this still works, just via `.length` on an empty string rather than an explicit early return).
+`submitCallback(event, setshowCreateModal)` only proceeds if `Object.keys(errors).length === 0` — but `errors` here is a variable captured once from the hook's own module scope, populated by the *previous* call to `validateEvent()`, not necessarily the errors from validating the `event` object being submitted right now; call `validateEvent()` immediately before `submitCallback` (as `CreateEvents.jsx`'s `handleSubmit` does) to keep them in sync.
+On success (`response.status === 201`): success toast, closes the modal, and calls SWR's `mutate(eventEndpoints.all)` to invalidate the events list cache (see [api-integration.md](./api-integration.md) for why nothing currently listens to that key).
+
+## Event display components
+
+- [EventsMarqueeCards.jsx](../../src/components/private/events/marquee/EventsMarqueeCards.jsx) — takes an `event` prop, renders cover image, name, and either a location (Offline) or a platform icon+name (Online), plus a formatted start date/time (via [getFormattedDate.js](../../src/utils/getFormattedDate.js)). Responsive text truncation at `window.innerWidth <= 500`. Not currently rendered by any page — looks intended for a "recent events" marquee (there's a commented-out `<Marquee>` block in `Profile.jsx` that would have used something like this).
+- [EventCard.jsx](../../src/components/shared/cards/event/EventCard.jsx) — the card rendered in the `Events.jsx` grid. **Does not use its data at all**: no props are accepted or destructured; every field (title "Food Marathon, 2025", club name, description, avatar images, "+300 Participated") is hardcoded JSX. `Events.jsx` passes `event={event}` to it, but the prop is ignored.
+- [EventSlider.jsx](../../src/components/shared/cards/event/EventSlider.jsx) — a custom (non-Swiper) auto-advancing carousel over a hardcoded array alternating `FeaturedEventImage`/`FeaturedEventCard`, paired two-per-slide. Advances every 3s via `setInterval`.
+- [FeaturedEventCard.jsx](../../src/components/shared/cards/event/FeaturedEventCard.jsx) / [FeaturedEventImage.jsx](../../src/components/shared/cards/event/FeaturedEventImage.jsx) — also fully static/hardcoded, no props.
+
+**Net effect:** as of today, nothing rendered under `/events` reflects real backend data — every visible card, count, and image is a hardcoded placeholder, even though the data-fetching (`getEvents`) and creation (`useEvent` + `CreateEvents`) pieces needed to make it real already exist and mostly work.
+
+## `HostedEvents` and `DetailedEvent` (empty stubs)
+
+- [src/components/private/events/hosted/HostedEvents.jsx](../../src/components/private/events/hosted/HostedEvents.jsx) — file exists but is **completely empty** (0 bytes); importing it would fail.
+- [src/pages/events/detailed/DetailedEvent.jsx](../../src/pages/events/detailed/DetailedEvent.jsx) — a one-line placeholder (`<div>DetailedEvent</div>`), not registered in `routesConfig.jsx` (no `/events/:id`-style route exists).

--- a/docs/specs/known-issues.md
+++ b/docs/specs/known-issues.md
@@ -1,0 +1,74 @@
+# Known Issues & Inconsistencies
+
+A single catalog of the cross-cutting bugs, dead code, and unresolved duplication discovered while writing these specs (August 2026), gathered from static reading of the code — none of this has been verified by running the app.
+Each item also appears inline in its relevant feature spec; this file exists so an agent can get the full picture in one read before making changes near any of these areas.
+Treat entries here as **things to be aware of**, not necessarily things to fix unless you were asked to — several are large enough in scope that they deserve their own ticket/PR.
+
+## Build / config
+
+- **`.env.example` documents the wrong variable name.** It shows `VITE_MILANAPI`, but every API call in the code reads `import.meta.env.VITE_API_URL`. A contributor following the example file verbatim will get a broken app with no base URL. Fix: rename the example var to `VITE_API_URL` (or add both, with a comment).
+- **`QueryClientProvider` (`@tanstack/react-query`) wraps the whole app but nothing uses it.** All data fetching goes through SWR or raw `axios`. Either start using it deliberately or remove the wrapper/dependency to reduce confusion for future contributors.
+
+## Routing
+
+- **`/donate` has no route**, even though `src/pages/donate/Donate.jsx` exists (and that file is separately broken — see below).
+- **`/events/:id`-equivalent has no route**, even though `src/pages/events/detailed/DetailedEvent.jsx` exists as a one-line stub.
+- **`src/pages/user/UserProfile.jsx` has no route** despite being a fairly complete page — see [onboarding-profile.md](./onboarding-profile.md).
+- **Footer links to `/terms`, `/privacy`, `/cookies`** — none of these routes exist; clicking them hits the 404 page.
+- **Navbar's account dropdown links to `/event/create`** (club users only) — no such route exists.
+
+## Broken imports / files that would fail to build if touched
+
+- **`src/pages/donate/Donate.jsx`** imports `../../components/Cards/SingleClubEvent/SingleClubEvent` and `../../components/Loading`, neither of which exists anymore. Since the page also has no route, this currently doesn't break the app (Vite doesn't bundle unreachable-but-still-source-present files until something imports the chain at build time — verify this is actually true for your Vite/Rollup config before relying on it; if the file is ever wired into a route or otherwise imported, the build will fail immediately).
+- **`src/components/private/events/hosted/HostedEvents.jsx` is a completely empty file** (0 bytes) — importing it fails immediately (no default export).
+- **`Events.jsx` imports `@components/shared/createEvent/createEvent`** (lowercase `c`), but the actual file is `CreateEvent.jsx`. This works on case-insensitive filesystems (macOS default, most local dev) but is a real risk on case-sensitive ones (Linux CI runners, some Docker base images) — worth fixing the casing regardless of whether it's currently causing failures for you.
+
+## Duplicated / conflicting implementations
+
+- **Two "create event" components** (`components/shared/createEvent/CreateEvent.jsx` and `components/private/events/create/CreateEvents.jsx`) with different fields, different validation, and — critically — the shared one calls the *user profile* update endpoint instead of the event-creation endpoint. See [events.md](./events.md).
+- **Two public profile pages** (`pages/profile/Profile.jsx`, routed; `pages/user/UserProfile.jsx`, not routed) covering overlapping functionality, with different "is this my own profile" checks (Redux vs. an unused cookie). See [onboarding-profile.md](./onboarding-profile.md).
+- **Two profile-edit modals** (`ProfileCompletion.jsx`, `ProfileUpdate.jsx`) that are ~80% identical JSX/logic, plus a `ProfileCompletion` component that itself has two Save buttons wired to two different code paths. See [onboarding-profile.md](./onboarding-profile.md).
+- **Two auth submit-button implementations** — `AuthButton.jsx` (unused) vs. inline markup in `SignIn.jsx`/`SignUp.jsx` (live). See [authentication.md](./authentication.md).
+- **Two validation systems for signup** — the lightweight two-field check inside `useAuth.js` (live) vs. the much more complete `useValidation.js` + `useFormLogic.js` pair (unused by any page). See [authentication.md](./authentication.md).
+- **Three different "is the user logged in" checks** and **three different logout cleanup sequences**, none centralized. See [state-management.md](./state-management.md).
+- **`userEndpoints.update` vs `userEndpoints.updateProfile`** — two endpoint constants pointing at different URLs; only `updateProfile` is actually used. See [api-integration.md](./api-integration.md).
+
+## Hardcoded/placeholder data standing in for real API data
+
+`Clubs.jsx` and `Events.jsx` both render arrays of 20 hardcoded fake records instead of calling the `getClubs()`/`getEvents()` functions that already exist for exactly this purpose (`src/integrations/Clubs.js`, `src/integrations/Events.js`).
+`EventCard`, `FeaturedEventCard`, and `FeaturedEventImage` don't even accept/use props — all content is static JSX.
+`Dashboard.jsx`'s cover photo, profile photo, and follower/event counts are static.
+`ClubCard`'s banner image and follower/event counts are static regardless of the `club` prop.
+`Landing.jsx`'s "Trusted by 300+ users" avatars are static.
+`TrackSection`'s analytics numbers are static and its tab-switcher isn't wired to anything.
+See the relevant feature spec ([clubs.md](./clubs.md), [events.md](./events.md), [dashboard.md](./dashboard.md), [landing-home.md](./landing-home.md)) for exactly which fields would need to become dynamic.
+
+## Validation that doesn't actually block submission
+
+Both `useProfileCompletion.validateForm` and `ProfileUpdate.validateForm` compute `newErrors`, call `setErrors(newErrors)`, and then call their respective PATCH API function **unconditionally**, regardless of whether `newErrors` is non-empty.
+The `Object.keys(newErrors).length === 0` check only affects the function's *return value*, not whether the request fires.
+In practice, the Save buttons are also `disabled` while required fields are empty, which covers the "required field missing" case at the UI layer — but the length/format checks (description 100–500 chars, numeric pincode) can still be bypassed and will still hit the API. See [onboarding-profile.md](./onboarding-profile.md).
+
+## Component-scaffolding that was built but never wired up
+
+These exist, work as isolated units, and appear to be intended for future/finished use — prefer extending or wiring these up over writing new ones that duplicate their purpose:
+- `ProfileElements.js` + `getProfileFields.js` — generic profile-field metadata, unused by the (hardcoded-field) `ProfileCompletion`/`ProfileUpdate` forms.
+- `useValidation.js` + `useFormLogic.js` — a fuller signup validator/handler pair, unused by the live `SignIn`/`SignUp` pages.
+- `AuthButton.jsx` — unused by the live auth pages.
+- `Modal.jsx` — a generic modal shell, unused; every modal in the app builds its own overlay markup instead.
+- `MilanInfoBanner` — a finished marketing section, unmounted from `Home.jsx`.
+- `Header.jsx` + `HeaderData.js` — has ready-made "clubs"/"events" copy, but `Clubs.jsx`/`Events.jsx` both build their own inline header instead of using it.
+- `PatchFetcher.js` — an SWR-style PATCH fetcher, unused (mutations go through direct `MilanApi.js` calls + `mutate()` instead).
+- `ClickAwayListener.jsx` — unused generic utility.
+- `getEvents()` / `getClubs()` (`src/integrations/*.js`) — real fetchers for events/clubs, unused because the pages that need them use hardcoded arrays instead.
+
+## Smaller one-off issues
+
+- `Events.jsx` passes `type="Clubs"` to `<ComponentHelmet>` instead of `"Events"` (that component does have an `"Events"` branch).
+- `Profile.jsx` renders its Subscribe/Sponsor/Edit/Logout button block twice in a row (copy-paste duplication, not an intentional repeated layout).
+- `Profile.jsx`'s map `<iframe>` reads `user?.iframe` (the viewer's own Redux state) instead of `details?.iframe` (the profile being viewed).
+- `Navbar.jsx` has a stray `console.log` of the full user object on every render.
+- `Dashboard.jsx` has a stray `console.log` in its "Edit Profile" click handler.
+- `useEvent.js`'s `submitCallback` checks a module-scope `errors` object populated by the *last* `validateEvent()` call rather than re-validating the event being submitted right now — callers must call `validateEvent()` immediately beforehand to keep these in sync (which `CreateEvents.jsx` does today, but it's an easy thing to break).
+- `ApiConnector.js` has a dead/unreachable status check (`if (response.status === 400) console.error("... status 600 ...")`) — the comment references 600 but the condition checks 400, and axios throws rather than resolving on 4xx by default, so this branch doesn't currently fire in practice.
+- `emailRegex` in `static/Constants.js` (`/^[a-zA-Z0-9._:$!%-]+@[a-zA-Z0-9.-]+.[a-zA-Z]$/`) has an unescaped `.` before the final TLD character class and requires only a single trailing letter — it's looser/buggier than a typical email regex (e.g. it would accept `a@bXc` because the unescaped `.` matches any character, and it only requires one character after the last literal dot). It's the one actually used by `useAuth.js`'s live email check, so tightening it would change real signup/signin validation behavior — coordinate before changing.

--- a/docs/specs/landing-home.md
+++ b/docs/specs/landing-home.md
@@ -1,0 +1,22 @@
+# Landing & Home
+
+The marketing/logged-out-friendly home experience, routed at `/`.
+
+## `Home.jsx`
+
+[src/pages/Home.jsx](../../src/pages/Home.jsx).
+Sets page `<title>`/meta via `<Helmet>`, scrolls to top on mount, and — if `Cookies.get("OAuthLoginInitiated")` is set — completes the Google OAuth flow by calling `successCallback()` and dispatching the result into Redux (see [authentication.md](./authentication.md)).
+Renders `<Landing />` then `<Footer />`.
+Does **not** render `<MilanInfoBanner />` — that component exists and is exported from the `components/private` barrel but is not currently mounted by any page (see below).
+
+## `Landing.jsx`
+
+[src/components/private/landing/Landing.jsx](../../src/components/private/landing/Landing.jsx).
+The hero section: `<Navbar />`, a headline that changes copy/wrapping at the `430px` breakpoint (tracked via a `window.resize` listener and local `windowWidth` state, not CSS media queries), and a CTA button that reads `isLoggedIn` from Redux (`selectIsLoggedIn`) to decide between "Sign up Today!" (`/auth/signup`) and "Explore our clubs" (`/clubs`).
+Below the CTA, a static "Trusted by 300+ users" block with four hardcoded GitHub avatar images — not derived from any real user/follower data.
+
+## `MilanInfoBanner` (built but not mounted)
+
+[src/components/private/infoBanner/Milaninfobanner.jsx](../../src/components/private/infoBanner/Milaninfobanner.jsx), exported as `MilanInfoBanner` from `components/private/index.js`.
+A three-section marketing scroller ("Collaborate.", "Connect.", "Build.") using `aos` (Animate On Scroll) for fade-up entrance animations, with responsive copy swapped at the `800px` breakpoint via inline `window.innerWidth` checks (same pattern as `Landing.jsx`, but here re-evaluated on every render rather than tracked in state — it won't update on resize without a re-render being triggered by something else).
+Not imported by `Home.jsx` or any other page — if you're asked to "add the info banner back to the homepage," this is the component to re-mount, not rebuild.

--- a/docs/specs/layout-navigation.md
+++ b/docs/specs/layout-navigation.md
@@ -1,0 +1,56 @@
+# Layout & Navigation
+
+Chrome shared across pages: navbar, footer, header banner, modal shell, loading spinner, back-to-top button, and the per-page `<Helmet>`/SEO pattern.
+None of these are rendered by a shared layout route — every page imports `<Navbar />` and (usually) `<Footer />` individually at the top of its own JSX, since routing has no nested/layout routes (see [architecture.md](./architecture.md)).
+
+## `Navbar`
+
+[src/components/shared/navbar/Navbar.jsx](../../src/components/shared/navbar/Navbar.jsx).
+Nav links are a local hardcoded array: Home `/`, Clubs `/clubs`, Trending `/trending`, Events `/events`, Shops `/shop`.
+Responsive behavior is driven by a `window.resize` listener + local `windowWidth` state (breakpoint `900px`), not CSS — above 900px shows the horizontal link row plus either a "Sign Up" CTA or (if `Cookies.get("Token") && isLoggedIn`) a "Profile ▾" dropdown trigger; below 900px shows a hamburger icon (or the user's avatar image if logged in) that opens a full mobile link panel.
+The account dropdown (`.nav_dropdown`) is toggled by directly mutating the DOM (`document.querySelector(".nav_dropdown").classList.toggle(...)`) rather than React state — this only exists once per page since `Navbar` itself is rendered once, so it's safe today but is worth noting if `Navbar` is ever rendered more than once on a page.
+The dropdown links to `/user/:userName` or `/dashboard` depending on `user?.userType`, and (for club users only) a currently-dead `/event/create` link (no such route exists).
+Logout: calls `Logout()`, then `resetUserData()` + `localStorage.clear()` (see [state-management.md](./state-management.md) for how this compares to the other two logout call sites).
+Has a stray `console.log("🚀 ~ Navbar ~ user:", user)` on every render — remove if touching this file.
+
+## `Footer`
+
+[src/components/shared/footer/Footer.jsx](../../src/components/shared/footer/Footer.jsx).
+Purely data-driven from [src/utils/footerLinksConfig.js](../../src/utils/footerLinksConfig.js): `quickStarts`, `resources` (external links open in a new tab if the path starts with `http`), `policies` (`/terms`, `/privacy`, `/cookies` — none of these routes exist in `routesConfig.jsx`), and `social` (LinkedIn/X/GitHub icons, mapped through a local `icons` lookup keyed by the string names `FaLinkedinIn`/`FaXTwitter`/`FaGithub`). To add a footer link, edit `footerLinksConfig.js` rather than this component.
+
+## `Header`
+
+[src/components/shared/header/Header.jsx](../../src/components/shared/header/Header.jsx) + [HeaderData.js](../../src/components/shared/header/HeaderData.js).
+A page-banner component taking a `type` prop (`"clubs"` or `"events"`) and looking up copy from `HeaderData.js`; falls back to generic "Default Header"/"Default Description" text if `type` doesn't match an entry.
+Swaps between a long and short description at the `800px` breakpoint (read once at render time via `window.innerWidth`, not tracked in state — same non-reactive pattern as `MilanInfoBanner`).
+**Not currently rendered by `Clubs.jsx` or `Events.jsx`** — both of those pages build their own inline header markup instead of using this component, despite `HeaderData.js` having entries specifically for `"clubs"` and `"events"`. Likely intended to be used there.
+
+## `Modal`
+
+[src/components/shared/modal/Modal.jsx](../../src/components/shared/modal/Modal.jsx).
+A generic overlay shell (CSS Modules) taking `children`, `onClose`, and `className`, with a built-in close button.
+Not currently used anywhere — `ProfileCompletion`, `ProfileUpdate`, and `CreateEvent`/`CreateEvents` all build their own bespoke `*_overlay`/`*_modal` markup instead of wrapping this component. If asked to standardize modal styling/behavior across the app, this is the shell to converge on.
+
+## `Loading`
+
+[src/components/shared/loading/Loading.jsx](../../src/components/shared/loading/Loading.jsx).
+A Bootstrap-spinner-styled loading indicator (class names `spinner-border`, `visually-hidden` — vestigial from an earlier Bootstrap-based version of this app; no Bootstrap CSS is actually imported anymore, so these classes rely entirely on `Loading.scss` to look right).
+Used as the "no data yet" fallback in `Clubs.jsx` and `Events.jsx` (though, per [clubs.md](./clubs.md)/[events.md](./events.md), those arrays are currently always populated with hardcoded data, so the fallback branch is effectively unreachable today), and in `Donate.jsx` (unrouted — see [donate-shop-trending.md](./donate-shop-trending.md)).
+
+## `BacktoTop`
+
+[src/components/shared/buttons/backtotopbutton/BacktoTop.jsx](../../src/components/shared/buttons/backtotopbutton/BacktoTop.jsx).
+Rendered once, globally, in `App.jsx` (outside `<Routes>`), so it appears on every page.
+Shows a scroll-to-top arrow once `document.documentElement.scrollTop` exceeds 250px, debounced (300ms) via a small hand-rolled `debounce` helper defined inline in the component.
+
+## `ClickAwayListener`
+
+[src/utils/ClickAwayListener.jsx](../../src/utils/ClickAwayListener.jsx).
+A generic wrapper that calls `onClickAway()` on any `mousedown` outside a `.click-away-listener` div. Not currently used anywhere in the app (the `Navbar` account dropdown, which would be a natural fit, instead relies on the user clicking the trigger again or navigating away).
+
+## `ComponentHelmet` (per-page SEO)
+
+[src/utils/ComponentHelmet.jsx](../../src/utils/ComponentHelmet.jsx).
+A `type`-keyed `<Helmet>` wrapper supporting `"Clubs"` and `"Events"` (exact string match, case-sensitive); returns `null` for anything else.
+Used by `Clubs.jsx` (`type="Clubs"`, correct) and `Events.jsx` (`type="Clubs"` — likely should be `"Events"`; see [events.md](./events.md)).
+Most other pages (`Home`, `SignIn`, `SignUp`, `Donate`) instead inline their own `<Helmet>` block directly rather than extending this component — if you add a new page needing SEO tags, either extend `ComponentHelmet` with a new `type` branch (consistent with `Clubs`/`Events`) or follow the inline-`<Helmet>` pattern (consistent with `Home`/auth pages); both exist today, no single convention has won yet.

--- a/docs/specs/onboarding-profile.md
+++ b/docs/specs/onboarding-profile.md
@@ -1,0 +1,75 @@
+# Onboarding & Profile
+
+Covers the post-signup "complete your profile" flow, editing an existing profile, and the two (largely redundant) public profile pages.
+
+## Profile completion flow (new users)
+
+After signup, a club/org account's profile is missing required fields (description, address).
+[checkMissingFields.js](../../src/utils/checkMissingFields.js) checks whether `city`, `state`, `address`, `country`, or `pincode` are `undefined` on the user object, or — for `userType === "club"` — whether `tagLine`/`description` are `undefined`.
+
+**Trigger sites:**
+- [Profile.jsx](../../src/pages/profile/Profile.jsx): on mount, if `!Cookies.get("skipProfileCompletion") && checkMissingFields(user) && trueUser` (i.e. you're viewing your own profile), shows the completion modal.
+- [Dashboard.jsx](../../src/pages/dashboard/Dashboard.jsx): shows the completion modal whenever `profileData?.user?.config?.hasCompletedProfile === false`, a different (and more explicit) signal than `checkMissingFields`.
+
+These two entry points use **different conditions** to decide whether to show the same modal — a user could satisfy one and not the other.
+See [known-issues.md](./known-issues.md).
+
+## `useProfileCompletion` hook
+
+[src/hooks/useProfileCompletion.js](../../src/hooks/useProfileCompletion.js) owns the completion form's local state: `credentials = { description, coverImage, address: { line1, line2, city, state, country, pincode } }`.
+
+- `handleChange(field)` — updates `description` at the top level, or nests into `address` for every other field name.
+- `validateForm(updatedCredentials)` — checks `description` is present and 100–500 characters, all six address subfields are present, and `pincode` is numeric.
+  Sets `errors` as a side effect, then — regardless of whether `newErrors` is empty — calls `completeProfileApiCall({ credentials: { ...updatedCredentials, config: { hasCompletedProfile: true } } })` (`PATCH /user/complete`) anyway.
+  The function only *returns* `Object.keys(newErrors).length === 0` after that API call, so validation failing does not currently prevent the submit request from firing; it only affects what gets returned to the caller and what error text renders. See [known-issues.md](./known-issues.md).
+- `handleSetDefaultValues(profileData)` / `handleResetFields()` — pre-fill or clear the form.
+- `clearError(field)` — removes one key from `errors`.
+
+## `ProfileCompletion` component
+
+[src/components/shared/profileCompletion/ProfileCompletion.jsx](../../src/components/shared/profileCompletion/ProfileCompletion.jsx) renders the modal: a cover-image dropzone (local preview only, via `URL.createObjectURL` — the file itself is never uploaded or attached to the API call), an "Organization Description" textarea with a live `x/500` counter, and address line1/line2/city/state/country/pincode inputs.
+
+There are **two Save buttons** wired to two different handlers: the header button calls `completeProfileApiCall(...)` directly and closes the modal + refetches on success; the form's own submit button calls `validateForm(credentials)` from the hook (whose behavior is described above).
+Both are gated on the same `disabled` condition (all required fields non-empty).
+This means depending on which button the user clicks, slightly different code paths run — worth consolidating if you touch this component.
+
+Props: `setShowEditModal`, `refreshProfileData` (an SWR `mutate` function passed down from the parent).
+
+## `ProfileUpdate` component (editing an existing profile)
+
+[src/components/shared/profileUpdate/ProfileUpdate.jsx](../../src/components/shared/profileUpdate/ProfileUpdate.jsx) is a near-duplicate of `ProfileCompletion`, used for editing an *already-completed* profile.
+Differences: it also edits `name`, it accepts a `profileData` prop to pre-fill from (instead of a separate `handleSetDefaultValues` call), it has a cover-image *and* a profile-picture dropzone (both preview-only, same caveat — neither file is actually uploaded), and its single Save button calls its own local `validateForm()`, which — like `useProfileCompletion`'s version — calls `updateUserProfile({ credentials })` (`PATCH /user/update`) regardless of validation outcome, for the same reason.
+
+Rendered from `Dashboard.jsx` when `openModal === true` (opened by the dashboard's "Edit Profile" button).
+Not currently rendered from `Profile.jsx`'s own "Edit profile" button — that button (`toggleProfileModal`) instead sets `editProfile = true` and opens `showProfileModal`, which renders `ProfileCompletion`, not `ProfileUpdate`.
+So editing from `/user/:userName` or `/club/:userName` opens the *completion* form, not the *update* form, even for a fully-completed profile.
+
+## Field metadata: `ProfileElements` and `getProfileFields`
+
+[src/constants/ProfileElements.js](../../src/constants/ProfileElements.js) is a declarative list of profile fields (`name`, `firstName`, `lastName`, `tagLine`, `description`, `city`, `state`, `address`, `country`, `pincode`) with label/placeholder/minimum-length/error-message metadata — intended for driving a generic field renderer.
+Not currently imported by any component; `ProfileCompletion`/`ProfileUpdate` hardcode their own JSX per field instead.
+
+[src/utils/getProfileFields.js](../../src/utils/getProfileFields.js) computes which fields are missing (`getMissingElements`) or which are all editable (`getEditableFields`) based on `userType` and whether `tagLine` is set.
+Also not currently imported anywhere.
+Both files look like scaffolding for a future generic/dynamic profile-form component.
+
+## Public profile pages (two, overlapping)
+
+There are **two separate "view a profile" pages** that both exist and are both routed, covering overlapping cases:
+
+### `Profile.jsx` — routed at `/user/:userName` and `/club/:userName`
+[src/pages/profile/Profile.jsx](../../src/pages/profile/Profile.jsx).
+Fetches via SWR: `clubEndpoints.details(params.userName)` (`GET /clubs?userName=...`) — used for *both* individual and club profiles, despite the endpoint's "club" naming.
+Renders differently based on `details?.userType === "club"` (name + tagline) vs. individual (firstName + lastName).
+`trueUser = user?.userName === params.userName` decides whether the viewer sees "Edit profile"/"Logout" or "Subscribe"/"Sponsor" (the latter two are static, non-functional buttons — no `onClick`).
+Renders an embedded Google Maps `<iframe>` for clubs only, defaulting to a hardcoded Kolkata location if `user?.iframe` is unset (note: reads `user?.iframe`, i.e. the *viewer's* Redux state, not `details?.iframe` — likely should read from the fetched `details`).
+Contains a duplicated block of markup: the `profile_header_ctadiv` (Subscribe/Sponsor/Edit/Logout buttons) is rendered twice in the JSX, once inside `.profile_header_details` and once again directly below it — a copy-paste leftover, not an intentional two-row layout. See [known-issues.md](./known-issues.md).
+
+### `UserProfile.jsx` — not routed
+[src/pages/user/UserProfile.jsx](../../src/pages/user/UserProfile.jsx) is a second, more visually developed profile page (profile picture, social icons, an "Events Attending" `Swiper` carousel with 6–8 hardcoded placeholder slides, responsive slide count).
+Fetches via SWR: `userEndpoints.details(params.slug)` (`GET /user?userName=...`).
+**This page is not referenced by `routesConfig.jsx` at all** — there is no route for it, so it is currently unreachable through normal navigation.
+It reads `Cookies.get("userName")`, a cookie that is never set anywhere else in the codebase (compare to `Profile.jsx`'s `trueUser` check, which uses Redux state instead) — so its "is this my own profile" branch can never evaluate true in the current app.
+Treat this as a work-in-progress replacement for (or alternate design of) `Profile.jsx` rather than a currently-active page.
+
+When asked to add profile features, confirm with whoever's asking whether they mean the *live* `Profile.jsx` or intend to finish wiring up `UserProfile.jsx`.

--- a/docs/specs/state-management.md
+++ b/docs/specs/state-management.md
@@ -1,0 +1,53 @@
+# State Management
+
+Three separate mechanisms hold state in this app, each for a different purpose.
+There is no single source of truth for "is the user logged in" — that fact is checked three different ways depending on the file (see the "isLoggedIn checks" section below), which is worth knowing before you touch auth-gated UI.
+
+## 1. Redux (the logged-in user's profile)
+
+- Store: [src/redux/store.js](../../src/redux/store.js).
+  A single root reducer (`combineReducers({ user: userReducer })`) wrapped in `redux-persist`'s `persistReducer` (key `"root"`, storage = `localStorage`, `version: 1`, no migrations configured).
+  `serializableCheck` is disabled in the middleware.
+- Slice: [src/redux/slice/userSlice.js](../../src/redux/slice/userSlice.js).
+  State shape starts as `{ isLoggedIn: false }` and grows dynamically — `updateUserData` merges (`{ ...state, ...action.payload }`) whatever the backend returns for the user object (name, email, userType, description, address, config, etc.) directly into the top level of `state.user`.
+  There is no fixed schema; every consumer reads optional fields defensively with `?.`.
+- Actions: `updateUserData(payload)` merges fields in; `toggleUserLogin()` flips `isLoggedIn`; `resetUserData()` resets to the initial `{ isLoggedIn: false }` (used on logout).
+- Selectors: `selectIsLoggedIn(state)` → `state.user.isLoggedIn`, `selectUser(state)` → `state.user`.
+  Some components use these selectors, others do `useSelector((state) => state.user)` or `useSelector((state) => state.user.isLoggedIn)` directly — both work, prefer the selectors in new code.
+
+**Where it's written:**
+- [useAuth.js](../../src/hooks/useAuth.js) — on successful sign-in/sign-up, dispatches `updateUserData({ ...response.data.user, isLoggedIn: true })`.
+- [Home.jsx](../../src/pages/Home.jsx) — after a Google OAuth redirect completes, dispatches `updateUserData(...)` then `toggleUserLogin()` (two separate dispatches, not one).
+- [Profile.jsx](../../src/pages/profile/Profile.jsx) and [Navbar.jsx](../../src/components/shared/navbar/Navbar.jsx) — on logout, dispatch `resetUserData()`.
+- [Dashboard.jsx](../../src/pages/dashboard/Dashboard.jsx) — on every SWR fetch of `userEndpoints.profile`, re-dispatches `updateUserData(data?.user)` in the `onSuccess` callback, keeping Redux in sync with the latest server copy.
+
+## 2. Zustand (`useAuthStore`)
+
+[src/store/useAuth.js](../../src/store/useAuth.js) is a single Zustand store holding exactly one field: `isLoading` (boolean) and its setter `toggleLoading(loading)`.
+It exists purely to drive button spinners/disabled states for form submissions that live outside the `useAuth` hook's own local `loading` state — e.g. [useFormLogic.js](../../src/hooks/useFormLogic.js), [AuthButton.jsx](../../src/components/shared/buttons/authbutton/AuthButton.jsx), [UserProfile.jsx](../../src/pages/user/UserProfile.jsx).
+Despite the name, it has nothing to do with authentication state itself — only with in-flight loading UI.
+
+There is no Zustand store for user/session data; all of that goes through Redux.
+
+## 3. Cookies (`js-cookie`)
+
+A `Token` cookie and other flags are read directly with `Cookies.get(...)` in several places, presumably set by the backend as an httpOnly-adjacent or client-visible cookie on login (cookie-setting itself happens server-side; the frontend never calls `Cookies.set` for `Token`).
+Cookies actually read in the frontend:
+
+| Cookie | Read in | Purpose |
+|---|---|---|
+| `Token` | `Navbar.jsx`, `DonotRenderWhenLoggedIn.jsx` | Presence used as a login signal, combined with the Redux `isLoggedIn` flag |
+| `skipProfileCompletion` | `Profile.jsx` | If set, suppresses the profile-completion modal even if fields are missing |
+| `userName` | `UserProfile.jsx` | Compared against the route's `:slug` param to decide if the viewer owns the profile |
+| `isLoggedIn` | `Donate.jsx` | Gate for the (currently unrouted) donate page — see [donate-shop-trending.md](./donate-shop-trending.md) |
+| `OAuthLoginInitiated` | `Home.jsx` | Set presumably by the backend/redirect flow before bouncing back from Google OAuth; its presence triggers `successCallback()` |
+
+`Cookies.remove("skipProfileCompletion")` and `localStorage.clear()` are both called on logout (in `Profile.jsx` and `Navbar.jsx` respectively) alongside `resetUserData()` — three different mechanisms cleaned up in three different places, not one central "logout" utility.
+
+## "Is the user logged in?" — three different checks in the wild
+
+1. `useSelector(selectIsLoggedIn)` — Redux only (used by `DonotRenderWhenLoggedIn`, `Landing.jsx`).
+2. `Cookies.get("Token") && isLoggedIn` — cookie presence *and* Redux flag together (used by `Navbar.jsx`, `DonotRenderWhenLoggedIn`).
+3. `Cookies.get("isLoggedIn")` — a *different* cookie name, unrelated to the `Token` cookie above (used only by the orphaned `Donate.jsx`).
+
+When adding new auth-gated UI, match whichever pattern the surrounding file already uses rather than introducing a fourth variant, and prefer pattern 2 (cookie + Redux) since that's what `Navbar` and the route guard use.

--- a/docs/specs/ui-kit.md
+++ b/docs/specs/ui-kit.md
@@ -1,0 +1,39 @@
+# Shared UI Kit & Styling Conventions
+
+## `Button`
+
+[src/components/shared/buttons/globalbutton/Button.jsx](../../src/components/shared/buttons/globalbutton/Button.jsx), styled via [Button.module.css](../../src/components/shared/buttons/globalbutton/Button.module.css) (CSS Modules).
+This is the one truly shared, widely-adopted primitive in the app — used across auth, profile, clubs, events, dashboard, and error pages.
+
+Props: `type` (default `"button"`), `variant` (default `"solid"`; also `"outline"` is used at call sites — check `Button.module.css` for the full set of variant classes before assuming others exist), `className`, `size`, `fontweight`, `to`, `disabled`, `isLoading`, `cypressfield` (sets `data-cy`, for Cypress test targeting), `onClickfunction` (the click handler prop — **not** `onClick`; passing a plain `onClick` would be spread onto the element via `...props` and technically still work as a native handler, but `onClickfunction` is the prop this codebase consistently uses at every call site, so use it for consistency).
+
+Behavior: if `to` is set **and** `navigator.onLine === true`, renders a `react-router-dom` `<Link>` instead of a `<button>` — an offline visitor passing `to` would silently get a plain, non-navigating `<button>` element instead (this is presumably intentional, to avoid dead navigation while offline, but it means `onClickfunction` also won't fire in that case since the button has no handler wired either way unless one was passed via `...props`).
+While `isLoading` is true, `children` are replaced with a `react-spinners` `ClipLoader`.
+
+## `AuthButton`
+
+[src/components/shared/buttons/authbutton/AuthButton.jsx](../../src/components/shared/buttons/authbutton/AuthButton.jsx) — see [authentication.md](./authentication.md). Built on top of `Button`, currently unused by the live auth pages.
+
+## Card components
+
+- `ClubCard` — see [clubs.md](./clubs.md).
+- `EventCard`, `EventSlider`, `FeaturedEventCard`, `FeaturedEventImage`, `EventsMarqueeCards` — see [events.md](./events.md).
+
+All card components are exported from `src/components/shared/index.js` (or imported directly by deep path — both patterns appear at different call sites; prefer the barrel for anything already exported there).
+
+## Styling conventions (inconsistent — know this before adding a component)
+
+Four different styling approaches coexist, chosen per-component with no clear rule:
+
+| Approach | Example |
+|---|---|
+| Plain `.scss` imported alongside the component, classes applied by string | `Navbar.scss`, `Footer.scss`, most page-level styles |
+| Plain `.css` imported the same way | `Header.css`, `UserProfile.css`, `Loading.scss` (mixed) |
+| CSS Modules (`.module.css`, imported as a `styles`/`style` object) | `Button.module.css`, `Modal.module.css` |
+| Global class-name conventions (BEM-ish, e.g. `profile_header_ctadiv`) shared across `.scss` files with no scoping | Most component `.scss` files |
+
+There's no CSS-in-JS despite `styled-components` and `@emotion/styled`/`@mui/styled-engine-sc` being installed dependencies (pulled in transitively by MUI) — no component in `src/` actually authors styled-components.
+When adding a new component, match the styling approach of its immediate siblings (e.g. new profile-related components → plain `.scss` + BEM-ish class names, matching `ProfileCompletion.scss`/`ProfileUpdate.scss`) rather than introducing a fifth pattern.
+
+[src/styles/Globals.scss](../../src/styles/Globals.scss) and [src/styles/App.css](../../src/styles/App.css) hold app-wide resets/variables and are imported once, from `App.jsx`.
+[src/styles/index.css](../../src/styles/index.css) is imported once, from `index.jsx`.


### PR DESCRIPTION
## Summary
Adds a full map of this codebase for AI coding agents (and future contributors), written by reading the whole `src/` tree end to end.

- `docs/specs/` — one markdown file per feature area (auth, onboarding/profile, dashboard, clubs, events, landing/home, layout/nav, UI kit, donate/shop/trending, error handling), plus `architecture.md`, `state-management.md`, `api-integration.md`, a `README.md` index, and `known-issues.md` cataloging bugs/dead code/duplicated implementations found along the way.
- `CLAUDE.md` — required reading pointer, a rule to ask before picking between the codebase's known duplicate implementations, and coding conventions matched to how most existing code already works.
- `AGENTS.md` — workflow entry point, backend-repo boundary, git/branching rule (never branch without explicit consent), and a running list of repo-specific guardrails.

No application code changes — docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)